### PR TITLE
Optionally create channels in a category

### DIFF
--- a/slack2discord_migration.py
+++ b/slack2discord_migration.py
@@ -88,7 +88,7 @@ def register_commands():
                 channels[channel['id']] = channel['name']
                 print(f"\tChannel ID: {channel['id']} -> Channel Name: {channels[channel['id']]}")
                 
-        category_id = int(args[1]) if len(args) > 0 else None
+        category_id = int(args[1]) if len(args) > 1 else None
         if category_id:
             category = ctx.guild.get_channel(category_id)
             category_name = category.name


### PR DESCRIPTION
Fixed a key not found exception for a message missing 'user' key, and odd replacement of "<@UID>" being transformed to "<@Name" for some reason, without the final '>'.

Thanks for your script @satoshi-hirose . I was looking for a script that pulled in files as well as text and automated importing all channels instead of importing them one at a time, or one JSON file at a time.

I made a few changes that suited me and I thought could be generally useful. I added the optional ability to specify a category ID for text channel creation when running the import, with `$import_all_channels directory [categoryID]`.

I ran into an exception with a message with no 'user' key for a slack Simple Poll app so check for 'user' being a key before trying to get the value.